### PR TITLE
Upgrade espressif/esp-sr to be version 2.1.5, to allow using wakeup word via "你好小安“

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -19,7 +19,7 @@ dependencies:
   78/xiaozhi-fonts: ~1.3.2
   espressif/led_strip: ^2.5.5
   espressif/esp_codec_dev: ~1.3.6
-  espressif/esp-sr: ~2.1.4
+  espressif/esp-sr: ~2.1.5
   espressif/button: ~4.1.3
   espressif/knob: ^1.0.0
   espressif/esp32-camera: ^2.0.15


### PR DESCRIPTION
更新 esp-sr 库版本到 2.1.5，支持”你好小安“唤醒词进行设备唤醒。